### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/trufflehog-scan.yml
+++ b/.github/workflows/trufflehog-scan.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - main
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/ozeranskii/image-vuln-scanner/security/code-scanning/1](https://github.com/ozeranskii/image-vuln-scanner/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. Since the workflow only needs to read the repository contents for secret scanning, we will set `contents: read` as the minimal required permission. This ensures the workflow has the least privileges necessary to perform its tasks.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
